### PR TITLE
Leaving IMG tags as inline keeps the space on the bottom for descenders. 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -234,6 +234,7 @@ blockquote{
 img{
 	max-width:100%;
 	height:auto;
+	display:block;
 }
 
 


### PR DESCRIPTION
Leaving IMG tags as inline keeps the space on the bottom for descenders. 
